### PR TITLE
Discord ingestion, wizard improvements, and docs cleanup (v0.3.5)Discord integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # Changelog
+## 2025-09-14 — v0.3.5
+
+- Feature — Discord mode UX and summaries
+  - Show friendly Discord channel name (e.g., "Guild / #clips") when ingesting.
+  - Log a concise summary for Discord runs: links found, raw clips fetched, filtered count, and compilations created.
+  - Remove duplicate "Created N compilations" log (now logged once from the pipeline).
+  - Normalize manifest path display to forward slashes on Windows.
+  - Files: `clippy/discord_ingest.py`, `main.py`.
+
+- Wizard — Safer prompts and preservation
+  - Source selection includes Discord; prompts mask secrets and can validate the bot token with a quick login.
+  - Re-running the wizard preserves existing Discord settings unless explicitly changed.
+  - Files: `scripts/setup_wizard.py`.
+
+- Docs — Update READMEs and examples
+  - Document Discord mode setup and usage, wizard flow, and transitions directory precedence.
+  - Ensure references to internal assets fallback are removed; clarify `TRANSITIONS_DIR` usage and `static.mp4` requirement.
+  - Files: `README.md`, `scripts/README.md`, `transitions/README.md`, `clippy.yaml.example`.
+
 
 All notable changes to this project are documented here. Dates are in YYYY-MM-DD and entries are grouped by date (newest first). This changelog blends commit history with implementation notes from development sessions to provide full context.
 
@@ -13,7 +32,7 @@ All notable changes to this project are documented here. Dates are in YYYY-MM-DD
 
 - Breaking/Docs — Removed portable build system; Python-only
   - Deleted portable build scripts and artifacts; documentation updated to reflect running from source only.
-  - Kept `_internal` support for optional sample assets; `CLIPPY_USE_INTERNAL=1` continues to work.
+  - Removed `_internal` sample asset fallback and CLIPPY_USE_INTERNAL; use TRANSITIONS_DIR instead.
   - Files: removed `build/` folder, updated `README.md`, `scripts/README.md`, `_internal/README.md`.
 
 ## 2025-09-14 — v0.3.2
@@ -72,8 +91,8 @@ All notable changes to this project are documented here. Dates are in YYYY-MM-DD
   - Files: `pipeline.py`, `clippy/naming.py`
 
 - Packaging — Internal data and ffprobe
-  - New internal data support: `_internal/` folder packaged and discoverable at runtime; resolver honors `CLIPPY_USE_INTERNAL=1` to prefer bundled assets.
-  - `transitions/static.mp4` is REQUIRED; build now stages it into `_internal/transitions/static.mp4` (and includes `transitions/` externally) to guarantee availability in portable builds.
+  - Internal data fallback removed; runtime resolver now uses TRANSITIONS_DIR, repo transitions/, or CWD transitions/.
+  - `transitions/static.mp4` is REQUIRED; ensure it exists under your transitions directory.
   - Bundled `ffprobe` alongside `ffmpeg` and `yt-dlp` in the portable output.
   - Updated PyInstaller spec and build scripts to include `_internal`, fonts, transitions, and `ffprobe`.
   - Files: `build/Clippy.spec`, `build/build.ps1`, `build/build.sh`, `_internal/README.md`, `utils.py`
@@ -85,8 +104,8 @@ All notable changes to this project are documented here. Dates are in YYYY-MM-DD
   - Files: `pipeline.py`
 
 - Health check & docs
-  - Health check now hints using `CLIPPY_USE_INTERNAL=1` if `transitions/static.mp4` is missing.
-  - README: grouped “Internal data and ENV” section covering `CLIPPY_USE_INTERNAL`, `TRANSITIONS_DIR`, and static.mp4 requirement.
+  - Health check messaging updated to focus on transitions directory and static.mp4 requirement.
+  - README updated to remove `CLIPPY_USE_INTERNAL` and clarify TRANSITIONS_DIR usage.
   - Files: `scripts/health_check.py`, `README.md`
 
 ## 2025-09-13
@@ -144,6 +163,6 @@ The following changes were implemented and verified during development and refle
 
 ## Notes
 
-- Breaking change: `transitions/static.mp4` is now required. Place your asset in `transitions/` or provide `--transitions-dir`.
-- Project runs from source; optional `_internal` assets are supported via `CLIPPY_USE_INTERNAL=1`.
+- Breaking change: `transitions/static.mp4` is required. Place your asset in `transitions/` or provide `--transitions-dir`.
+- Project runs from source.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Confirm settings (default prompt) or skip with `-y`:
 python main.py --broadcaster somechannel -y
 ```
 
+- Discord integration (optional):
+  - Add DISCORD_TOKEN to .env and set discord.channel_id in clippy.yaml (or pass --discord-channel-id)
+  - python .\main.py --discord --discord-channel-id 123456789012345678 -y
+  - The tool will read recent messages in the channel, extract Twitch clip links, resolve them via Helix, and build compilations
+```
+
 Auto-expand lookback to gather more clips:
 ```powershell
 python main.py --broadcaster somechannel --auto-expand --expand-step-days 14 --max-lookback-days 180

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Create highlight compilations directly from Twitch clips. Audio is ON by default
 
 ## Features
 - Twitch Helix ingestion with simple date window and auto-expand lookback
+- Discord channel ingestion (optional): read clip links from a Discord channel using discord.py
 - Min-views filter, weighted selection, and themed colorized logs
 - Creator avatar overlay, transitions, and output finalization to `output/`
 - yt-dlp downloads with retries; `.env` or env-based credentials
@@ -22,12 +23,15 @@ python .\scripts\setup_wizard.py
 ```
 
 ### What the setup wizard does
+- Source selection: choose Twitch or Discord as your clip source
 - Guides you through entering your Twitch credentials and saves them to a `.env` file
 - Writes a starter `clippy.yaml` with sensible defaults (clips per compilation, min views, quality, fps/resolution)
 - Optionally sets a default broadcaster so you can run without specifying `--broadcaster`
+- Discord setup (optional): prompts for Discord channel ID and supports masked bot token entry; can perform a quick token login check
+- Preserves existing settings on re-run (including Discord config); secrets are masked in prompts
 - Checks for ffmpeg/yt-dlp and NVENC availability; suggests fixes if missing
 - Helps you select or create a transitions folder (`transitions/`), explains the required `static.mp4`
-- Offers to use internal sample transitions with `CLIPPY_USE_INTERNAL=1` (when `_internal/transitions` exists)
+- Requires `transitions/static.mp4`; you can set a custom directory with `--transitions-dir` or TRANSITIONS_DIR
 - You can run with just: `python .\main.py -y` after saving defaults
 
 You can re-run the wizard at any time to adjust settings; it will merge with the existing YAML and leave custom edits intact.
@@ -40,7 +44,7 @@ You can re-run the wizard at any time to adjust settings; it will merge with the
 Key env vars (advanced):
 - `TWITCH_CLIENT_ID`, `TWITCH_CLIENT_SECRET` – Twitch credentials used by the Helix API
 - `TRANSITIONS_DIR` – point to a custom transitions folder (`static.mp4` required)
-- `CLIPPY_USE_INTERNAL=1` – prefer packaged `_internal/transitions` when available
+  
 
 ## Usage
 Basic:
@@ -52,11 +56,25 @@ Confirm settings (default prompt) or skip with `-y`:
 ```powershell
 python main.py --broadcaster somechannel -y
 ```
+### Discord mode (optional)
 
-- Discord integration (optional):
-  - Add DISCORD_TOKEN to .env and set discord.channel_id in clippy.yaml (or pass --discord-channel-id)
-  - python .\main.py --discord --discord-channel-id 123456789012345678 -y
-  - The tool will read recent messages in the channel, extract Twitch clip links, resolve them via Helix, and build compilations
+Prerequisites:
+- A Discord bot in your server with permission to read the target channel
+- The “Message Content Intent” enabled for your bot in the Discord Developer Portal
+- Bot token saved to `.env` as `DISCORD_TOKEN`
+
+Config:
+- Set `discord.channel_id` and optional `discord.message_limit` in `clippy.yaml`
+- Or pass `--discord-channel-id` and `--discord-limit` on the CLI
+
+Run:
+```powershell
+python .\main.py --discord --discord-channel-id 123456789012345678 -y
+```
+
+What happens:
+- Clippy reads recent messages from the channel, extracts Twitch clip links, resolves them via Helix, and builds compilations
+- Logs display the channel name (e.g., “Guild / #clips”), the number of links found, raw clips fetched, clips after min-views, and compilations created
 ```
 
 Auto-expand lookback to gather more clips:
@@ -95,11 +113,11 @@ Sections include: Required, Window & selection, Output & formatting, Transitions
 
 ### Internal data and ENV
 
-- `static.mp4` is REQUIRED. Place it under `transitions/`. If you also have internal sample assets under `_internal/transitions`, set `CLIPPY_USE_INTERNAL=1` to prefer those.
+- `static.mp4` is REQUIRED. Place it under `transitions/` or point TRANSITIONS_DIR to a folder that contains it.
 - Override transitions location with `TRANSITIONS_DIR` (absolute or relative path).
 - Common ENV:
   - `TWITCH_CLIENT_ID`, `TWITCH_CLIENT_SECRET`: Twitch API credentials
-  - `CLIPPY_USE_INTERNAL=1`: Prefer `_internal` sample data (when present)
+  - TRANSITIONS_DIR: Set a custom transitions directory
   - `TRANSITIONS_DIR=path`: Use a specific transitions folder
 
 ### Transitions 101: creating and validating assets

--- a/clippy.yaml.example
+++ b/clippy.yaml.example
@@ -83,7 +83,10 @@ discord:
   channel_id: 000000000000000000
   # How many recent messages to scan for clip links
   message_limit: 200
+  # Notes:
+  # - Save your bot token in .env as DISCORD_TOKEN (do not put secrets in YAML)
+  # - Enable "Message Content Intent" in the Discord Developer Portal
 
 # Notes:
 # - Use TRANSITIONS_DIR env var to point to a custom transitions folder.
-# - Set CLIPPY_USE_INTERNAL=1 to prefer packaged internal transitions/static when available.
+# - Set TRANSITIONS_DIR to a custom directory if your transitions are not under ./transitions.

--- a/clippy.yaml.example
+++ b/clippy.yaml.example
@@ -77,6 +77,13 @@ assets:
   # outro: [outro.mp4, outro_2.mp4]
   # transitions: [transition_01.mp4, transition_02.mp4, transition_03.mp4]
 
+discord:
+  # Optional: used when running with --discord
+  # Discord channel ID to read clip links from
+  channel_id: 000000000000000000
+  # How many recent messages to scan for clip links
+  message_limit: 200
+
 # Notes:
 # - Use TRANSITIONS_DIR env var to point to a custom transitions folder.
 # - Set CLIPPY_USE_INTERNAL=1 to prefer packaged internal transitions/static when available.

--- a/clippy/__init__.py
+++ b/clippy/__init__.py
@@ -4,4 +4,4 @@ This package contains helper modules extracted from main.py to keep the entrypoi
 """
 
 # Semantic version of the Clippy tool. Bump this for releases.
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/clippy/cli.py
+++ b/clippy/cli.py
@@ -83,6 +83,13 @@ def parse_args() -> argparse.Namespace:
     g_nvenc.add_argument("--temporal-aq", type=str, help="NVENC temporal AQ enable (0/1)")
     g_nvenc.add_argument("--aq-strength", type=str, help="NVENC AQ strength 0-15")
 
+    # Discord mode
+    g_discord = p.add_argument_group("Discord integration")
+    g_discord.add_argument("--discord", action="store_true", help="Enable Discord mode: read clip links from a channel instead of Helix search")
+    g_discord.add_argument("--discord-channel-id", type=int, help="Discord channel ID to read from (else clippy.yaml discord.channel_id)")
+    g_discord.add_argument("--discord-token", type=str, help="Discord bot token (else DISCORD_TOKEN env or .env)")
+    g_discord.add_argument("--discord-limit", type=int, default=200, help="Number of recent messages to scan for clip links")
+
     # Misc
     g_misc = p.add_argument_group("Misc")
     g_misc.add_argument("-y", "--yes", action="store_true", help="Auto-confirm the settings prompt")

--- a/clippy/config_loader.py
+++ b/clippy/config_loader.py
@@ -71,6 +71,10 @@ DEFAULTS: Dict[str, Any] = {
     "container_ext": "mp4",
     "container_flags": "-movflags +faststart",
     "yt_format": "bestvideo[ext=mp4][height<=1080]+bestaudio[ext=m4a]/best[ext=mp4][height<=1080]",
+
+    # Discord (optional)
+    "discord_channel_id": None,
+    "discord_message_limit": 200,
 }
 
 
@@ -165,6 +169,7 @@ def load_merged_config(defaults: dict[str, Any] | None = None, env: dict[str, st
     beh = data.get("behavior", {}) if isinstance(data, dict) else {}
     assets = data.get("assets", {}) if isinstance(data, dict) else {}
     identity = data.get("identity", {}) if isinstance(data, dict) else {}
+    discord = data.get("discord", {}) if isinstance(data, dict) else {}
 
     # Map fields to existing names
     merged["amountOfClips"] = _coerce_int(sel.get("clips_per_compilation"), merged.get("amountOfClips"))
@@ -211,6 +216,14 @@ def load_merged_config(defaults: dict[str, Any] | None = None, env: dict[str, st
 
     # Identity
     merged["default_broadcaster"] = _coerce_str(identity.get("broadcaster"), merged.get("default_broadcaster", ""))
+
+    # Discord
+    try:
+        ch_val = discord.get("channel_id") if isinstance(discord, dict) else None
+        merged["discord_channel_id"] = int(ch_val) if ch_val is not None else merged.get("discord_channel_id")
+    except Exception:
+        pass
+    merged["discord_message_limit"] = _coerce_int(discord.get("message_limit") if isinstance(discord, dict) else None, merged.get("discord_message_limit", 200))
 
     # Environment overrides (non-secret convenience)
     if env.get("TRANSITIONS_DIR"):

--- a/clippy/config_loader.py
+++ b/clippy/config_loader.py
@@ -230,7 +230,6 @@ def load_merged_config(defaults: dict[str, Any] | None = None, env: dict[str, st
         merged["TRANSITIONS_DIR"] = env.get("TRANSITIONS_DIR")
         # also expose as config.transitions_dir for compatibility with utils
         merged["transitions_dir"] = env.get("TRANSITIONS_DIR")
-    if env.get("CLIPPY_USE_INTERNAL"):
-        merged["CLIPPY_USE_INTERNAL"] = env.get("CLIPPY_USE_INTERNAL")
+    # Deprecated: CLIPPY_USE_INTERNAL support removed; prefer explicit TRANSITIONS_DIR
 
     return merged

--- a/clippy/discord_ingest.py
+++ b/clippy/discord_ingest.py
@@ -1,0 +1,113 @@
+"""Discord ingest utilities
+
+Reads recent messages from a configured Discord channel and extracts Twitch clip
+URLs or IDs. Intended to be used as a source list for Helix lookups.
+
+Requirements:
+    - A Discord bot token with read access to the target channel
+    - Message Content Intent enabled in the Discord Developer Portal
+
+We use discord.py with a minimal Client and read channel history on_ready.
+"""
+from __future__ import annotations
+
+import os
+import re
+import asyncio
+from typing import List
+
+import discord
+
+_TWITCH_CLIP_RE = re.compile(r"https?://clips\.twitch\.tv/([\w-]+)", re.IGNORECASE)
+_TWITCH_URL_ID_RE = re.compile(r"https?://(?:www\.)?twitch\.tv/[^/]+/clip/([\w-]+)", re.IGNORECASE)
+
+
+def extract_clip_ids_from_text(text: str) -> List[str]:
+    ids: List[str] = []
+    for m in _TWITCH_CLIP_RE.finditer(text or ""):
+        ids.append(m.group(1))
+    for m in _TWITCH_URL_ID_RE.finditer(text or ""):
+        ids.append(m.group(1))
+    # Deduplicate preserving order
+    seen = set()
+    out: List[str] = []
+    for i in ids:
+        if i and i not in seen:
+            seen.add(i)
+            out.append(i)
+    return out
+
+
+async def fetch_recent_clip_ids(token: str, channel_id: int, limit: int = 200) -> List[str]:
+    """Fetch recent messages from a channel and extract Twitch clip IDs.
+
+    - token: Discord bot token
+    - channel_id: numeric ID of the channel to read
+    - limit: number of messages to scan
+    """
+    intents = discord.Intents.default()
+    intents.message_content = True  # Required to read message content
+
+    class _Collector(discord.Client):
+        def __init__(self, *, intents: discord.Intents, channel_id: int, limit: int):
+            super().__init__(intents=intents)
+            self._channel_id = channel_id
+            self._limit = limit
+            self.ids: List[str] = []
+
+        async def on_ready(self):
+            channel = self.get_channel(self._channel_id)
+            if channel is None:
+                try:
+                    channel = await self.fetch_channel(self._channel_id)
+                except Exception as e:
+                    await self.close()
+                    raise RuntimeError(f"Failed to fetch channel: {e}")
+            if not hasattr(channel, "history"):
+                await self.close()
+                raise RuntimeError("Channel does not support history() (must be TextChannel)")
+            try:
+                async for message in channel.history(limit=self._limit):
+                    self.ids.extend(extract_clip_ids_from_text(getattr(message, "content", "") or ""))
+                    for att in getattr(message, "attachments", []) or []:
+                        if getattr(att, "url", None):
+                            self.ids.extend(extract_clip_ids_from_text(att.url))
+            finally:
+                await self.close()
+
+    client = _Collector(intents=intents, channel_id=channel_id, limit=limit)
+    await client.start(token, reconnect=False)
+    # Deduplicate preserving order
+    seen = set()
+    out: List[str] = []
+    for i in client.ids:
+        if i and i not in seen:
+            seen.add(i)
+            out.append(i)
+    return out
+
+
+def load_discord_token(arg_token: str | None = None) -> str:
+    """Precedence: CLI arg > DISCORD_TOKEN env > .env file."""
+    if arg_token:
+        return arg_token
+    tok = os.getenv("DISCORD_TOKEN")
+    if tok:
+        return tok
+    # Lightweight .env parsing
+    path = ".env"
+    if os.path.isfile(path):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if "=" not in line:
+                        continue
+                    k, v = line.split("=", 1)
+                    if k.strip() == "DISCORD_TOKEN":
+                        return v.strip().strip('"').strip("'")
+        except Exception:
+            pass
+    raise SystemExit("Missing Discord token: set DISCORD_TOKEN in env or .env, or provide --discord-token")

--- a/main.py
+++ b/main.py
@@ -50,7 +50,11 @@ from clippy.twitch_ingest import (
     fetch_creator_avatars,
     fetch_clips_by_ids,
 )
-from clippy.discord_ingest import fetch_recent_clip_ids, load_discord_token
+"""
+Note on optional Discord dependency:
+We only import discord-related helpers when --discord mode is requested.
+This lets users run Twitch-only flows without installing discord.py.
+"""
 
 # Import processing helpers from existing main module
 from clippy.pipeline import create_compilations_from, stage_one, stage_two  # DB removed
@@ -116,6 +120,16 @@ def main():  # noqa: C901
         _pl.amountOfClips = amountOfClips
         _pl.amountOfCompilations = amountOfCompilations
         _pl.reactionThreshold = reactionThreshold
+    except Exception:
+        pass
+
+    # If running in Discord mode and no broadcaster provided, prefill from config default for nicer summaries
+    try:
+        if getattr(args, "discord", False) and not getattr(args, "broadcaster", None):
+            import clippy.config as _cfg
+            _def_b_prefill = getattr(_cfg, "default_broadcaster", "")
+            if _def_b_prefill:
+                args.broadcaster = _def_b_prefill
     except Exception:
         pass
 
@@ -271,19 +285,20 @@ def main():  # noqa: C901
     except Exception:
         pass
 
-    # If broadcaster not provided via CLI, use default from config if present
-    try:
-        _def_b = globals().get("default_broadcaster", "")
-    except Exception:
-        _def_b = ""
-    if not getattr(args, "broadcaster", None):
-        if _def_b:
-            args.broadcaster = _def_b
-            log("Using default broadcaster from config: " + str(_def_b), 1)
-        else:
-            log("No broadcaster provided and no default configured in clippy.yaml (identity.broadcaster)", 5)
-            log("Set identity.broadcaster via setup_wizard or provide --broadcaster", 1)
-            raise SystemExit(2)
+    # If not in Discord mode, require a broadcaster (CLI or config). In Discord mode, we'll infer later.
+    if not getattr(args, "discord", False):
+        try:
+            _def_b = globals().get("default_broadcaster", "")
+        except Exception:
+            _def_b = ""
+        if not getattr(args, "broadcaster", None):
+            if _def_b:
+                args.broadcaster = _def_b
+                log("Using default broadcaster from config: " + str(_def_b), 1)
+            else:
+                log("No broadcaster provided and no default configured in clippy.yaml (identity.broadcaster)", 5)
+                log("Set identity.broadcaster via setup_wizard or provide --broadcaster", 1)
+                raise SystemExit(2)
 
     # Interactive confirmation (default). Use -y/--yes to skip.
     if not getattr(args, "yes", False):
@@ -361,7 +376,12 @@ def main():  # noqa: C901
 
     if getattr(args, "discord", False):
         # Discord mode: read clip IDs from a channel and resolve via Helix
-        from clippy.config import DEFAULTS as _CFG_DEFAULTS  # type: ignore
+        try:
+            from clippy.discord_ingest import fetch_recent_clip_ids, load_discord_token  # type: ignore
+        except Exception as _imp_err:
+            log("Discord mode requires the optional dependency 'discord.py'", 5)
+            log("Install it with: pip install discord.py", 1)
+            raise SystemExit(_imp_err)
         try:
             import clippy.config as _cfg
             _discord_channel_id = getattr(_cfg, "discord_channel_id", None)
@@ -375,11 +395,22 @@ def main():  # noqa: C901
         d_token = load_discord_token(args.discord_token if hasattr(args, 'discord_token') else None)
         import asyncio as _asyncio
         log("Reading Discord channel for clip links", 1)
-        clip_ids = _asyncio.run(fetch_recent_clip_ids(d_token, int(ch_id), limit=int(args.discord_limit or _discord_limit)))
+        clip_ids, _channel_disp = _asyncio.run(
+            fetch_recent_clip_ids(d_token, int(ch_id), limit=int(args.discord_limit or _discord_limit))
+        )
+        try:
+            if _channel_disp:
+                log("Discord channel: " + str(_channel_disp), 2)
+        except Exception:
+            pass
         # Dedupe and limit to max_clips
         clip_ids = list(dict.fromkeys(clip_ids))[: args.max_clips]
         if not clip_ids:
             raise SystemExit("No clip links found in the specified Discord channel")
+        try:
+            log("Found " + str(len(clip_ids)) + " clip links", 2)
+        except Exception:
+            pass
         log("Fetching clips by IDs from Helix", 1)
         clips = fetch_clips_by_ids(clip_ids, cid, token)
         # Broadcaster for naming: use the first clip's broadcaster_name/login if present, else fallback
@@ -566,7 +597,11 @@ def main():  # noqa: C901
         _m_path = _os.path.join(output, "manifest.json")
         with open(_m_path, "w", encoding="utf-8") as f:
             _json.dump(manifest, f, indent=2)
-        log("Wrote manifest: " + _m_path, 1)
+        try:
+            _disp_path = _m_path.replace('\\', '/')
+        except Exception:
+            _disp_path = _m_path
+        log("Wrote manifest: " + _disp_path, 1)
     except Exception as e:
         log("WARN Failed to write manifest: " + str(e), 2)
     log("Done", 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ requests>=2.31.0
 Pillow>=10.0.0
 yachalk>=0.1.5
 yt-dlp>=2024.3.10
+discord.py>=2.3
 PyYAML>=6.0.1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 This directory contains utility scripts that support setup, media preparation, and validation for running from source.
 
-- `setup_wizard.py` — Guided first-time setup. Creates `.env`, writes `clippy.yaml`, checks binaries, helps you choose a transitions folder (or prefer internal sample ones), and can generate `run_clippy.ps1` for quick launching.
+- `setup_wizard.py` — Guided first-time setup. Creates `.env`, writes `clippy.yaml`, checks binaries, helps you choose a transitions folder, and can generate `run_clippy.ps1` for quick launching. Includes optional Discord setup.
 - `health_check.py` — Standalone preflight: verifies ffmpeg/yt-dlp presence, NVENC availability, Python packages, required folders, transitions/static.mp4, fonts, and `.env` credentials.
 - `import_media.py` — Normalize or convert any source video/image into a valid transition asset (`intro`, `transition`, `outro`, `static`). Ensures correct codecs, fps, resolution, and loudness.
 - `make_transitions.py` — Generate multiple short `transition_XX.mp4` clips by slicing random segments from a long source video.
@@ -31,7 +31,8 @@ If the file doesn’t exist yet, run a small compile first (e.g., `--clips 4 --c
   - Pick quality preset and tune resolution/fps/audio
   - Configure transitions behavior and audio preferences
   - Set cache/output paths and concurrency
-  - Prefer bundled transitions via `CLIPPY_USE_INTERNAL=1` or specify a transitions directory
+  - Specify a transitions directory via TRANSITIONS_DIR or place assets under transitions/
+  - Optional: configure Discord (channel ID, token check); preserves existing settings on re-run
   - Generates a ready-to-run PowerShell helper `run_clippy.ps1`
 
 Usage (PowerShell):
@@ -46,8 +47,12 @@ Typical usage:
   - `python .\scripts\health_check.py`
 
 Notes:
-- The checker prefers local `bin/` and `assets/fonts/` paths when running from source. If `_internal` assets exist and `CLIPPY_USE_INTERNAL=1` is set, those will be used for transitions.
+- The checker prefers local `bin/` and `assets/fonts/` paths when running from source.
 - Coloring is minimal and safe for Windows consoles.
+
+## Discord usage
+
+See the main README “Discord mode (optional)” section for end-to-end setup and requirements.
 
 ## Transitions tools quick reference
 

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -107,6 +107,12 @@ def check_python_packages() -> None:
             print(f"{status_tag('OK')} Python package: {display}")
         except Exception:
             print(f"{status_tag('MISSING')} Python package: {display}")
+    # Optional
+    try:
+        __import__("discord")
+        print(f"{status_tag('OK')} Python package: discord.py (optional)")
+    except Exception:
+        print(f"{status_tag('INFO')} Python package: discord.py not installed (Discord mode optional)")
 
 
 def check_dirs_and_assets(ffmpeg_path: str | None) -> None:

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -133,7 +133,6 @@ def check_dirs_and_assets(ffmpeg_path: str | None) -> None:
         print(f"{status_tag('OK')} transitions/static.mp4 present")
     else:
         print(f"{status_tag('MISSING')} transitions/static.mp4 missing (required)")
-        print("        Try setting CLIPPY_USE_INTERNAL=1 if you packaged _internal/transitions/static.mp4")
     # counts for intros/outros/transitions and probability
     try:
         import clippy.config as _cfg

--- a/scripts/setup_wizard.py
+++ b/scripts/setup_wizard.py
@@ -122,12 +122,26 @@ def _print_header():
     print(THEME.bar(bar) + "\n")
 
 
+def _mask_default(s: str, left: int = 6, right: int = 2) -> str:
+    try:
+        if not s:
+            return s
+        if len(s) <= left + right + 3:
+            # For very short strings, show first half and last char
+            cut = max(1, len(s) // 2)
+            return f"{s[:cut]}…{s[-1:]}"
+        return f"{s[:left]}…{s[-right:]}"
+    except Exception:
+        return s
+
+
 def _prompt_str(label: str, default: Optional[str] = None, secret: bool = False) -> str:
     d = f"{default}" if default not in (None, "") else ""
     while True:
         prompt = THEME.label(label)
         if d:
-            prompt += THEME.sep(" [") + THEME.default(d) + THEME.sep("]")
+            disp = _mask_default(d) if secret else d
+            prompt += THEME.sep(" [") + THEME.default(disp) + THEME.sep("]")
         prompt += THEME.sep(": ")
         val = input(prompt).strip()
         if not val and default is not None:
@@ -218,7 +232,6 @@ def _find_static_candidates() -> list[Path]:
     root = Path(__file__).resolve().parents[1]
     candidates = [
         root / "transitions" / "static.mp4",
-        root / "_internal" / "transitions" / "static.mp4",
         root / "cache" / "_trans" / "static.mp4",
     ]
     return [p for p in candidates if p.is_file()]
@@ -266,30 +279,103 @@ def main():
             pass
     cid_default = existing.get("TWITCH_CLIENT_ID") or os.getenv("TWITCH_CLIENT_ID", "")
     sec_default = existing.get("TWITCH_CLIENT_SECRET") or os.getenv("TWITCH_CLIENT_SECRET", "")
-    client_id = _prompt_str("Twitch Client ID", cid_default or None)
-    client_secret = _prompt_str("Twitch Client Secret", sec_default or None)
+    client_id = _prompt_str("Twitch Client ID", cid_default or None, secret=True)
+    client_secret = _prompt_str("Twitch Client Secret", sec_default or None, secret=True)
 
-    # Step 2: Defaults for selection and identity (broadcaster prompt only for Twitch source)
-    print("\n" + THEME.header("Step 2: Clip selection & identity"))
-    if source_choice == "twitch":
-        _shown = str(DEFAULT_BROADCASTER) if (DEFAULT_BROADCASTER not in (None, "")) else "(none)"
-        print(THEME.text("  Current default broadcaster:") + " " + THEME.path(_shown))
-        print(THEME.text("  Set a default to skip typing --broadcaster each run (leave blank to keep)."))
+    # Step 2 (Discord only): Discord configuration (moved near top)
+    discord_section = None
+    discord_token = ""
+    if source_choice == "discord":
+        print("\n" + THEME.header("Step 2: Discord setup"))
+        print(THEME.text("  1) Enable Developer Mode in Discord: User Settings -> Advanced -> Developer Mode"))
+        print(THEME.text("  2) Right-click the target channel -> Copy Channel ID"))
+        print(THEME.text("  3) Create a bot at https://discord.com/developers/applications and copy the Bot Token (Bot tab)"))
+        print(THEME.text("  4) Ensure the 'Message Content Intent' is enabled for your bot"))
+        print(THEME.text("  5) Invite the bot to your server with permissions to read the channel"))
+        # Defaults: from clippy.yaml (via load_merged_config) and .env
+        try:
+            ch_def = _existing_cfg.get('discord_channel_id') if isinstance(_existing_cfg, dict) else None
+            lim_def = int(_existing_cfg.get('discord_message_limit', 200)) if isinstance(_existing_cfg, dict) else 200
+        except Exception:
+            ch_def = None
+            lim_def = 200
+        tok_def = existing.get("DISCORD_TOKEN") or os.getenv("DISCORD_TOKEN", "")
+        ch = _prompt_str("Discord channel ID (numeric)", str(ch_def) if ch_def else None)
+        lim = _prompt_int("Discord message scan limit", lim_def, 1)
+        discord_token = _prompt_str("Discord bot token (stored in .env)", tok_def or None, secret=True)
+        try:
+            discord_section = {"channel_id": int(ch), "message_limit": int(lim)}
+        except Exception:
+            discord_section = {"channel_id": ch, "message_limit": int(lim)}
+
+        # Optional: quick token validation (no-op login)
+        def _mask(s: str) -> str:
+            try:
+                return _mask_default(s)
+            except Exception:
+                return s
+        try:
+            # Only attempt if a token string is present
+            if discord_token:
+                try:
+                    import discord  # type: ignore
+                    import asyncio  # type: ignore
+                except Exception:
+                    print(THEME.warn("  Skipping token validation: discord.py not installed"))
+                else:
+                    async def _login_once(tok: str) -> tuple[bool, str]:
+                        try:
+                            intents = discord.Intents.none()
+                            client = discord.Client(intents=intents)
+                            try:
+                                await client.login(tok)
+                            except discord.LoginFailure:
+                                return False, "Invalid Discord token (login failed)"
+                            except Exception as e:
+                                return False, f"Login error: {e}"
+                            finally:
+                                try:
+                                    await client.close()
+                                except Exception:
+                                    pass
+                            return True, "Discord token login OK"
+                        except Exception as e:
+                            return False, f"Validation error: {e}"
+                    try:
+                        ok, msg = asyncio.run(asyncio.wait_for(_login_once(discord_token), timeout=6.0))
+                        if ok:
+                            print(THEME.success("  ✔ Discord token validated (login OK)"))
+                            print(THEME.text("    Ensure 'Message Content Intent' is enabled for your bot in the Developer Portal."))
+                        else:
+                            print(THEME.warn("  ⚠ Discord token check: " + msg))
+                            print(THEME.text("    Tip: Copy the token from the Bot tab (not Application ID/Public Key)."))
+                    except Exception as e:
+                        print(THEME.warn(f"  ⚠ Token validation skipped (timeout or error): {e}"))
+            else:
+                print(THEME.warn("  No Discord token provided; you'll need DISCORD_TOKEN in .env for --discord mode."))
+        except Exception:
+            # Non-fatal; continue wizard
+            pass
+
+    # Step 3: Defaults for selection and identity (always capture a broadcaster name)
+    print("\n" + THEME.header("Step 3: Clip selection & identity"))
+    _shown = str(DEFAULT_BROADCASTER) if (DEFAULT_BROADCASTER not in (None, "")) else "(none)"
+    print(THEME.text("  Current default broadcaster:") + " " + THEME.path(_shown))
+    print(THEME.text("  Even in Discord mode, we use a broadcaster name for naming and defaults."))
+    print(THEME.text("  Set a default to skip typing --broadcaster each run (leave blank to keep)."))
     min_views = _prompt_int("Minimum views to include a clip", DEFAULT_MIN_VIEWS, 0)
     clips_per_comp = _prompt_int("Clips per compilation", DEFAULT_CLIPS, 1)
     num_compilations = _prompt_int("Number of compilations per run", DEFAULT_COMPS, 1)
-    default_broadcaster = ""
-    if source_choice == "twitch":
-        default_broadcaster = _prompt_str("Default broadcaster", DEFAULT_BROADCASTER or "")
+    default_broadcaster = _prompt_str("Default broadcaster (Twitch username)", DEFAULT_BROADCASTER or "")
 
-    # Step 3: Quality and format
-    print("\n" + THEME.header("Step 3: Output quality & format"))
+    # Step 4: Quality and format
+    print("\n" + THEME.header("Step 4: Output quality & format"))
     preset_name, bitrate = _quality_menu()
     resolution = _prompt_str("Resolution (e.g., 1920x1080)", DEFAULT_RES)
     fps = _prompt_str("Framerate (e.g., 60)", DEFAULT_FPS)
     audio_br = _prompt_str("Audio bitrate (e.g., 192k)", DEFAULT_AUDIO_BR)
 
-    # Step 4: Transitions
+    # Step 5: Transitions
     _transitions_explain()
     use_random = not _prompt_yes_no("Disable random transitions?", default_yes=DEFAULT_NO_RANDOM)
     trans_prob = DEFAULT_TRANS_PROB
@@ -297,54 +383,44 @@ def main():
         trans_prob = _prompt_float("Probability to insert a transition (0.0 - 1.0)", DEFAULT_TRANS_PROB, 0.0, 1.0)
     silence_static = _prompt_yes_no("Silence static.mp4 audio?", default_yes=DEFAULT_SILENCE_STATIC)
 
-    # Step 5: Paths & concurrency
-    print("\n" + THEME.header("Step 5: Paths & concurrency"))
+    # Step 6: Paths & concurrency
+    print("\n" + THEME.header("Step 6: Paths & concurrency"))
     cache_dir = _prompt_str("Cache directory", DEFAULT_CACHE)
     output_dir = _prompt_str("Output directory", DEFAULT_OUTPUT)
     conc = _prompt_int("Max concurrent workers (downloads/normalize)", DEFAULT_CONC, 1)
 
-    # Step 6: Transitions location
-    print("\n" + THEME.header("Step 6: Transitions directory"))
-    print(THEME.text("  The tool requires transitions/static.mp4. You can set a custom directory or use the bundled internal data."))
-    use_internal = _prompt_yes_no("Prefer bundled internal transitions when available?", default_yes=True)
+    # Step 7: Transitions location
+    print("\n" + THEME.header("Step 7: Transitions directory"))
+    print(THEME.text("  The tool requires transitions/static.mp4. Place one in transitions/ or set a custom directory."))
     trans_dir = _prompt_str("Custom transitions directory (blank to skip)", "")
 
-    # Step 7 (Discord only): Discord configuration
-    discord_section = None
-    discord_token = ""
-    if source_choice == "discord":
-        print("\n" + THEME.header("Step 7: Discord setup"))
-        print(THEME.text("  1) Enable Developer Mode in Discord: User Settings -> Advanced -> Developer Mode"))
-        print(THEME.text("  2) Right-click the target channel -> Copy Channel ID"))
-        print(THEME.text("  3) Create a bot at https://discord.com/developers/applications and copy the Bot Token"))
-        print(THEME.text("  4) Ensure the 'Message Content Intent' is enabled for your bot"))
-        print(THEME.text("  5) Invite the bot to your server with permissions to read the channel"))
-        ch = _prompt_str("Discord channel ID (numeric)")
-        lim = _prompt_int("Discord message scan limit", 200, 1)
-        discord_token = _prompt_str("Discord bot token (stored in .env)")
-        try:
-            discord_section = {"channel_id": int(ch), "message_limit": int(lim)}
-        except Exception:
-            discord_section = {"channel_id": ch, "message_limit": int(lim)}
-
-    # Write .env
-    lines = [
-        f"TWITCH_CLIENT_ID={client_id}",
-        f"TWITCH_CLIENT_SECRET={client_secret}",
-    ]
-    if use_internal:
-        lines.append("CLIPPY_USE_INTERNAL=1")
+    # Write .env (merge with existing to avoid dropping values like DISCORD_TOKEN)
+    env_out = dict(existing)
+    env_out["TWITCH_CLIENT_ID"] = client_id
+    env_out["TWITCH_CLIENT_SECRET"] = client_secret
     if trans_dir:
-        lines.append(f"TRANSITIONS_DIR={trans_dir}")
+        env_out["TRANSITIONS_DIR"] = trans_dir
+    # Preserve TRANSITIONS_DIR if user left blank
+    # Update DISCORD_TOKEN only if provided this run (e.g., in Discord mode); otherwise preserve existing
     if discord_token:
-        lines.append(f"DISCORD_TOKEN={discord_token}")
+        env_out["DISCORD_TOKEN"] = discord_token
+    # Emit in a stable order (Twitch first), then others
+    ordered_keys = ["TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET", "TRANSITIONS_DIR", "DISCORD_TOKEN"]
+    other_items = [(k, v) for k, v in env_out.items() if k not in ordered_keys]
+    lines = []
+    for k in ordered_keys:
+        if k in env_out and env_out[k] not in (None, ""):
+            lines.append(f"{k}={env_out[k]}")
+    for k, v in other_items:
+        if v not in (None, ""):
+            lines.append(f"{k}={v}")
     try:
         env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
         print("\n" + THEME.success(f"Wrote {env_path.resolve()}"))
     except Exception as e:
         print("\n" + THEME.warn(f"WARN: Failed to write .env: {e}"))
 
-    # Write YAML config (clippy.yaml)
+    # Write YAML config (clippy.yaml) — preserve existing discord section if not updated this run
     cfg = {
         "selection": {
             "min_views": min_views,
@@ -379,10 +455,27 @@ def main():
         },
         "_meta": {"generated_by": f"setup_wizard v{CLIPPY_VERSION}"},
     }
-    if discord_section:
-        cfg["discord"] = discord_section
+    # Load existing YAML (if any) to preserve discord block when not provided this run
+    existing_yaml = {}
     try:
         import yaml  # type: ignore
+        yaml_path = Path("clippy.yaml")
+        if yaml_path.is_file():
+            existing_yaml = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+            if not isinstance(existing_yaml, dict):
+                existing_yaml = {}
+    except Exception:
+        existing_yaml = {}
+    if discord_section:
+        cfg["discord"] = discord_section
+    else:
+        # Keep prior discord settings if present in file
+        try:
+            if isinstance(existing_yaml, dict) and existing_yaml.get("discord"):
+                cfg["discord"] = existing_yaml.get("discord")
+        except Exception:
+            pass
+    try:
         yaml_text = yaml.safe_dump(cfg, sort_keys=False)
         yaml_path = Path("clippy.yaml")
         yaml_path.write_text(yaml_text, encoding="utf-8")
@@ -404,7 +497,7 @@ def main():
     if statics:
         print(THEME.text("  Found static.mp4 here: ") + THEME.path(f"{statics[0]}"))
     else:
-        print(THEME.warn("  static.mp4 not found in transitions/. If you don't have one, set CLIPPY_USE_INTERNAL=1 or set --transitions-dir."))
+        print(THEME.warn("  static.mp4 not found in transitions/. Place one there or set --transitions-dir to a folder that contains it."))
     print("\n" + THEME.header("All set! Next steps:"))
     if source_choice == "discord":
         print(THEME.text("  1) Run a compile using Discord as the source:"))

--- a/transitions/README.md
+++ b/transitions/README.md
@@ -17,8 +17,8 @@ Normalization & audio policy:
 
 Resolution order for transitions directory:
 1) `TRANSITIONS_DIR` environment variable (absolute or relative)
-2) Packaged internal data when `CLIPPY_USE_INTERNAL=1`
-3) Standard locations next to the executable or repository (e.g., `./transitions`, `./_internal/transitions`)
+2) `transitions_dir` in `clippy.yaml` (if set)
+3) Repository `./transitions` or current working directory `./transitions`
 
 Tips:
 - `static.mp4` is required; the pipeline inserts it between every clip.


### PR DESCRIPTION
Summary

Adds Discord ingestion mode to read Twitch clip links from a Discord channel, then resolve via Helix.
Logs now show a friendly Discord channel name (e.g., “Guild / #clips”) and a concise summary: links found → raw → filtered → compilations.
Setup wizard improvements: source selection (Twitch/Discord), masked secrets, optional Discord token validation, preserves settings on re-run.
Documentation refresh: clarified transitions directory precedence; removed internal assets fallback; reinforced static.mp4 requirement.
Logging polish: removed duplicate “Created N compilations”; manifest path displayed with forward slashes on Windows.
Notable changes

Code
main.py: Discord summary lines; manifest path display normalized; duplicate compilation log removed.
clippy/discord_ingest.py: returns channel display name for friendlier logs.
clippy/init.py: bump to 0.3.5.
Docs
README.md: Discord mode section and wizard updates.
scripts/README.md: optional Discord setup, removed internal asset mentions.
transitions/README.md: transitions_dir precedence clarified.
clippy.yaml.example: Discord notes (DISCORD_TOKEN in .env, Message Content Intent).
CHANGELOG.md: v0.3.5 entry.
Behavior notes

Twitch-only runs don’t require discord.py; Discord imports are deferred.
[static.mp4](vscode-file://vscode-app/c:/Users/broca/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) remains required; use TRANSITIONS_DIR or transitions/ paths.
Validation

Syntax checks: PASS.
Health + sequencing task: PASS.
Discord E2E depends on bot token and channel permissions (Message Content Intent).
Checklist

 Run a Discord-mode test against a staging channel
 Confirm wizard’s token validation flow and copy
 Merge and tag v0.3.5